### PR TITLE
Get rid of blocking waits on task pool threads

### DIFF
--- a/dotnet-statsig-tests/Common/StatsigTest.cs
+++ b/dotnet-statsig-tests/Common/StatsigTest.cs
@@ -156,7 +156,7 @@ namespace dotnet_statsig_tests
             StatsigClient.LogEvent("event_3", "string");
             StatsigClient.LogEvent("event_4", null, new Dictionary<string, string> { { "key", "value" } });
 
-            StatsigClient.Shutdown();
+            await StatsigClient.Shutdown();
 
             // Verify log event requets for exposures and custom logs
             requestBody = _server.LogEntries.ElementAt(1).RequestMessage.Body;
@@ -397,7 +397,7 @@ namespace dotnet_statsig_tests
             StatsigServer.LogEvent(user, "event_3", "string");
             StatsigServer.LogEvent(user, "event_4", null, new Dictionary<string, string> { { "key", "value" } });
 
-            StatsigServer.Shutdown();
+            await StatsigServer.Shutdown();
 
             // Verify log event requets for exposures and custom logs
             requestBody = _server.LogEntries.ElementAt(1).RequestMessage.Body;

--- a/dotnet-statsig-tests/Server/ServerSDKConsistencyTest.cs
+++ b/dotnet-statsig-tests/Server/ServerSDKConsistencyTest.cs
@@ -107,7 +107,7 @@ namespace dotnet_statsig_tests
                         string.Format("Secondary exposures are different for config {0}. Expected {1} but got {2}", config.Key, stringifyExposures(serverResult.SecondaryExposures), stringifyExposures(sdkConfigResult.SecondaryExposures)));
                 }
             }
-            driver.Shutdown();
+            await driver.Shutdown();
         }
 
         private bool compareSecondaryExposures(List<IReadOnlyDictionary<string, string>> exposures1, List<IReadOnlyDictionary<string, string>> exposures2)

--- a/dotnet-statsig/dotnet-statsig.csproj
+++ b/dotnet-statsig/dotnet-statsig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net471</TargetFrameworks>
     <RootNamespace>statsig_dotnet</RootNamespace>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>Statsig</PackageId>

--- a/dotnet-statsig/src/Statsig/Client/StatsigClient.cs
+++ b/dotnet-statsig/src/Statsig/Client/StatsigClient.cs
@@ -19,10 +19,10 @@ namespace Statsig.Client
             await _singleDriver.Initialize(user);
         }
 
-        public static void Shutdown()
+        public static async Task Shutdown()
         {
             EnsureInitialized();
-            _singleDriver.Shutdown();
+            await _singleDriver.Shutdown();
         }
 
         public static bool CheckGate(string gateName)

--- a/dotnet-statsig/src/Statsig/Network/EventLogger.cs
+++ b/dotnet-statsig/src/Statsig/Network/EventLogger.cs
@@ -31,7 +31,7 @@ namespace Statsig.Network
             _flushTimer.Elapsed += async (sender, e) => await FlushEvents();
         }
 
-        public void Enqueue(EventLog entry)
+        public async void Enqueue(EventLog entry)
         {
             if (entry.IsErrorLog)
             {
@@ -48,17 +48,11 @@ namespace Statsig.Network
             _eventLogQueue.Add(entry);
             if (_eventLogQueue.Count >= _maxQueueLength)
             {
-                ForceFlush();
+                await FlushEvents();
             }
         }
 
-        internal void ForceFlush()
-        {
-            var task = FlushEvents();
-            task.Wait();
-        }
-
-        async Task FlushEvents()
+        internal async Task FlushEvents()
         {
             if (_eventLogQueue.Count == 0)
             {
@@ -86,11 +80,11 @@ namespace Statsig.Network
             };
         }
 
-        public void Shutdown()
+        public async Task Shutdown()
         {
             _flushTimer.Stop();
             _flushTimer.Dispose();
-            ForceFlush();
+            await FlushEvents();
         }
     }
 }

--- a/dotnet-statsig/src/Statsig/Network/EventLogger.cs
+++ b/dotnet-statsig/src/Statsig/Network/EventLogger.cs
@@ -31,7 +31,7 @@ namespace Statsig.Network
             _flushTimer.Elapsed += async (sender, e) => await FlushEvents();
         }
 
-        public async void Enqueue(EventLog entry)
+        public void Enqueue(EventLog entry)
         {
             if (entry.IsErrorLog)
             {
@@ -48,7 +48,17 @@ namespace Statsig.Network
             _eventLogQueue.Add(entry);
             if (_eventLogQueue.Count >= _maxQueueLength)
             {
-                await FlushEvents();
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        await FlushEvents();
+                    }
+                    catch
+                    {
+                        // TODO: Log this
+                    }
+                });
             }
         }
 

--- a/dotnet-statsig/src/Statsig/Network/RequestDispatcher.cs
+++ b/dotnet-statsig/src/Statsig/Network/RequestDispatcher.cs
@@ -92,7 +92,7 @@ namespace Statsig.Network
             int retries = 0,
             int backoff = 1)
         {
-            System.Threading.Thread.Sleep(backoff * 1000);
+            await Task.Delay(backoff * 1000);
             return await Fetch(endpoint, body, retries - 1, backoff * backoffMultiplier);
         }
     }

--- a/dotnet-statsig/src/Statsig/Server/StatsigServer.cs
+++ b/dotnet-statsig/src/Statsig/Server/StatsigServer.cs
@@ -26,10 +26,10 @@ namespace Statsig.Server
             await _singleDriver.Initialize();
         }
 
-        public static void Shutdown()
+        public static async Task Shutdown()
         {
             EnsureInitialized();
-            _singleDriver.Shutdown();
+            await _singleDriver.Shutdown();
         }
 
         public static async Task<bool> CheckGate(StatsigUser user, string gateName)


### PR DESCRIPTION
This PR addresses two places where task pool threads would perform blocking waits, which is an anti-pattern that can easily lead to Thread Pool starvation.  The first was a call to `Thread.Sleep()` which has been replaced by `Task.Delay()`.  The second was a method that internally called `Task.Wait()`, the fix for which required converting the whole call chain leading to that code into asynchronous methods.  This meant that the return type from `StatsigClient.Shutdown()` and `StatsigServer.Shutdown()` was changed from `void` to `Task`.

I also updated the list of target frameworks for the library to include .NET 6.0, and then took advantage of that framework's support for [IAsyncDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable).  And finally, I dropped netcoreapp2.1 from the list of target frameworks as it is no longer supported by Microsoft, and any apps targeting that framework can use of the netstandard2.0 build of this library.