### PR TITLE
Make the EventLogger and SpecStore thread safe

### DIFF
--- a/dotnet-statsig/src/Statsig/Network/EventLogger.cs
+++ b/dotnet-statsig/src/Statsig/Network/EventLogger.cs
@@ -35,13 +35,9 @@ namespace Statsig.Network
         {
             if (entry.IsErrorLog)
             {
-                if (_errorsLogged.Contains(entry.ErrorKey))
+                if (!_errorsLogged.Add(entry.ErrorKey))
                 {
                     return;
-                }
-                else
-                {
-                    _errorsLogged.Add(entry.ErrorKey);
                 }
             }
 

--- a/dotnet-statsig/src/Statsig/Server/Evaluation/Evaluator.cs
+++ b/dotnet-statsig/src/Statsig/Server/Evaluation/Evaluator.cs
@@ -351,11 +351,7 @@ namespace Statsig.Server.Evaluation
                         var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(value.ToString()));
                         var str = Convert.ToBase64String(bytes);
                         var substr = str.Substring(0, 8);
-                        var ids = _store.IDLists[target.ToString()]?.IDs;
-                        if (ids != null)
-                        {
-                            result = ids.Contains(substr);
-                        }
+                        result = _store.IDListContainsValue(target.ToString(), substr);
                     }
                     break;
                 default:

--- a/dotnet-statsig/src/Statsig/Server/Evaluation/Evaluator.cs
+++ b/dotnet-statsig/src/Statsig/Server/Evaluation/Evaluator.cs
@@ -28,9 +28,9 @@ namespace Statsig.Server.Evaluation
             _initialized = true;
         }
 
-        internal void Shutdown()
+        internal async Task Shutdown()
         {
-            _store.Shutdown();
+            await _store.Shutdown();
         }
 
         internal ConfigEvaluation CheckGate(StatsigUser user, string gateName)

--- a/dotnet-statsig/src/Statsig/Server/ServerDriver.cs
+++ b/dotnet-statsig/src/Statsig/Server/ServerDriver.cs
@@ -60,8 +60,10 @@ namespace Statsig.Server
 
         public async Task Shutdown()
         {
-            evaluator.Shutdown();
-            await _eventLogger.Shutdown();
+            await Task.WhenAll(
+                evaluator.Shutdown(),
+                _eventLogger.Shutdown());
+
 #if SUPPORTS_ASYNC_DISPOSAL
             await ((IAsyncDisposable)this).DisposeAsync();
 #else


### PR DESCRIPTION
The primary purpose of this PR is to make the `EventLogger` and `SpecStore` classes thread safe, and as part of that work I also converted the old timer-based periodic task logic to instead use traditional tasks with delays.  Here are the main features of the work covered in this PR:

- Timer-based logic now uses long running Tasks that terminate in response to a CancellationToken
- `EventLogger` uses a simple lock to guard all access to the `_eventLogQueue` and `_errorsLogged` fields.
- `SpecStore` uses a ReaderWriterLock to guard access to the `_idLists`. This allows parallel evaluation of conditions that need to reference the ID lists, but writes are synchronized.
- A small handful of other miscellaneous fixes, including defensively guarding against some possible `NullReferenceExceptions`, simplifying HashSet Contains/Add logic, and avoiding modifying a dictionary while iterating through it.