### PR TITLE
Abstracting out the ID storage part

### DIFF
--- a/dotnet-statsig-tests/Server/SpecStoreResponseData.cs
+++ b/dotnet-statsig-tests/Server/SpecStoreResponseData.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Statsig.Server.Lib;
+using Statsig.Lib;
 
 namespace dotnet_statsig_tests
 {
@@ -67,7 +67,7 @@ namespace dotnet_statsig_tests
             };
             foreach (var id in ids)
             {
-                list.IDs.Add(id);
+                list.Store.Add(id);
             }
             return list;
         }

--- a/dotnet-statsig-tests/Server/SpecStoreTest.cs
+++ b/dotnet-statsig-tests/Server/SpecStoreTest.cs
@@ -1,26 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
+﻿using System.Collections.Generic;
 using Xunit;
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Statsig;
 using Statsig.Server;
-using Statsig.Server.Lib;
+using Statsig.Lib;
 using System.Threading.Tasks;
-using Moq;
-using System.Net;
-using System.Text;
 using WireMock.ResponseProviders;
 using WireMock;
 using WireMock.Settings;
 using WireMock.Server;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
-using WireMock.Util;
-using System.Linq;
 
 namespace dotnet_statsig_tests
 {

--- a/dotnet-statsig/src/Statsig/Lib/IIDStore.cs
+++ b/dotnet-statsig/src/Statsig/Lib/IIDStore.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Statsig.Lib
+{
+    public interface IIDStore: IDisposable
+    {
+        int Count { get; }
+        bool Add(string id);
+        bool Remove(string id);
+        bool Contains(string id);
+        void TrimExcess();
+    }
+}

--- a/dotnet-statsig/src/Statsig/Lib/InMemoryIDStore.cs
+++ b/dotnet-statsig/src/Statsig/Lib/InMemoryIDStore.cs
@@ -3,14 +3,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Statsig.Server.Lib
+namespace Statsig.Lib
 {
-    class ConcurrentHashSet<T>: IDisposable
+    class InMemoryIDStore: IDisposable, IIDStore
     {
         readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(
           LockRecursionPolicy.SupportsRecursion
         );
-        internal readonly HashSet<T> _hashSet = new HashSet<T>();
+        internal readonly HashSet<string> _hashSet = new HashSet<string>();
 
         public int Count
         {
@@ -31,7 +31,7 @@ namespace Statsig.Server.Lib
             }
         }
 
-        public bool Add(T item)
+        public bool Add(string item)
         {
             _lock.EnterWriteLock();
             try 
@@ -47,7 +47,7 @@ namespace Statsig.Server.Lib
             }
         }
 
-        public bool Remove(T item)
+        public bool Remove(string item)
         {
             _lock.EnterWriteLock();
             try 
@@ -95,7 +95,7 @@ namespace Statsig.Server.Lib
             }
         }
 
-        public bool Contains(T item)
+        public bool Contains(string item)
         {
             _lock.EnterReadLock();
             try 
@@ -122,6 +122,7 @@ namespace Statsig.Server.Lib
             if (disposing)
             {
                 _lock.Dispose();
+                _hashSet.Clear();
             }
         }
     }

--- a/dotnet-statsig/src/Statsig/StatsigOptions.cs
+++ b/dotnet-statsig/src/Statsig/StatsigOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Statsig.Lib;
 
 namespace Statsig
 {
@@ -12,6 +13,7 @@ namespace Statsig
         public double IDListsSyncInterval = Constants.SERVER_ID_LISTS_SYNC_INTERVAL_IN_SEC;
 
         private Dictionary<string, string> _additionalHeaders;
+        private Func<IIDStore> _idStoreFactory = null;
         
         public StatsigOptions(): this(null)
         {
@@ -34,6 +36,12 @@ namespace Statsig
         internal IReadOnlyDictionary<string, string> AdditionalHeaders
         {
             get { return _additionalHeaders; }
+        }
+
+        public Func<IIDStore> IDStoreFactory
+        {
+            get { return _idStoreFactory; }
+            set { _idStoreFactory = value; }
         }
 
         public void AddRequestHeader(string key, string value)


### PR DESCRIPTION
This way we can offer stores other than in-memory ones.  These stores can be plugged in by offering a lambda that creates a new IIDStore.