### PR TITLE
fix: #43 appVersion is unknown in case Assembly.GetEntryAssembly() is…

### DIFF
--- a/dotnet-statsig/src/Statsig/Client/ClientDriver.cs
+++ b/dotnet-statsig/src/Statsig/Client/ClientDriver.cs
@@ -406,7 +406,7 @@ namespace Statsig.Client
                     ["sessionID"] = _sessionID,
                     ["stableID"] = PersistentStore.StableID,
                     ["locale"] = CultureInfo.CurrentUICulture.Name,
-                    ["appVersion"] = Assembly.GetEntryAssembly()!.GetName()!.Version!.ToString()!,
+                    ["appVersion"] = Assembly.GetEntryAssembly()?.GetName().Version!.ToString() ?? "unknown",
                     ["systemVersion"] = Environment.OSVersion.Version.ToString(),
                     ["systemName"] = systemName,
                     ["sdkType"] = sdkDetails.SDKType,


### PR DESCRIPTION
Fix issue #43 

Sets appVersion of StatsigMetadata dictionary to "unknown" in case `Assembly.GetEntryAssembly()` is null (happens in test projects).