### PR TITLE
[codex] Pin GitHub Actions workflow references

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,10 +11,10 @@ jobs:
     timeout-minutes: 10
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@8e6bd2905eef86446227f003dda1deb3916c4aaf # v2
         with:
           dotnet-version: "6.x.x"
 

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -12,6 +12,6 @@ jobs:
     if: startsWith(github.head_ref, 'releases/') || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: statsig-io/statsig-publish-sdk-action@main
+      - uses: statsig-io/statsig-publish-sdk-action@c0740fb8a2d4813522cc09bb8c4e826bb78ce6ab # main
         with:
           kong-private-key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger Scheduled Test Runs
         if: github.event.repository.private
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |
             const args = {


### PR DESCRIPTION
Pin floating external GitHub Actions workflow refs to immutable SHAs.

Why are we doing this? Please see the rationale doc: https://docs.google.com/document/d/1qOURCNx2zszQ0uWx7Fj5ERu4jpiYjxLVWBWgKa2wTsA/edit?tab=t.0

Did this break you? Please roll back and let hintz@ know
